### PR TITLE
clarify separator

### DIFF
--- a/info/task_description.html
+++ b/info/task_description.html
@@ -17,7 +17,7 @@
 </p>
 
 <p>
-    Coordinates are given as a string with the latitude and longitude separated by whitespace.
+    Coordinates are given as a string with the latitude and longitude separated by comma and/or whitespace.
     Latitude and longitude are represented in the follow format:
 </p>
 


### PR DESCRIPTION
verification uses " " and ", " and "," as latitude-longitude separator
